### PR TITLE
Show path on error

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -42,6 +42,7 @@ function createExecutor(command) {
         if (bool) {
           exec(command, { cwd: dir }, function(err, stdout, stderr) {
             if (err || stderr) {
+              console.log('\033[31m' + path.basename(dir) + '/\033[39m');
               debug(dir);
               debug('stdout: ' + stdout);
               debug('stderr: ' + stderr);


### PR DESCRIPTION
When git-all encounters an error (for example "error: Pull is not possible because you have unmerged files"), it doesn't tell you which directory caused the problem. This change will show the error-causing directory name in red.